### PR TITLE
Add camera controls for cursed forest battle

### DIFF
--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -5,11 +5,13 @@ import { mercenaryEngine } from '../utils/MercenaryEngine.js';
 import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
+import { CameraControlEngine } from '../utils/CameraControlEngine.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
         super('CursedForestBattle');
         this.stageManager = null;
+        this.cameraControl = null;
     }
 
     create() {
@@ -21,6 +23,7 @@ export class CursedForestBattleScene extends Scene {
 
         this.stageManager = new BattleStageManager(this);
         this.stageManager.createStage('battle-stage-cursed-forest');
+        this.cameraControl = new CameraControlEngine(this);
 
         // 아군 배치
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
@@ -44,6 +47,10 @@ export class CursedForestBattleScene extends Scene {
 
             if (this.stageManager) {
                 this.stageManager.destroy();
+            }
+            if (this.cameraControl) {
+                this.cameraControl.destroy();
+                this.cameraControl = null;
             }
         });
     }

--- a/src/game/utils/CameraControlEngine.js
+++ b/src/game/utils/CameraControlEngine.js
@@ -1,0 +1,58 @@
+export class CameraControlEngine {
+    constructor(scene) {
+        this.scene = scene;
+        this.camera = scene.cameras.main;
+        this.isDragging = false;
+        this.dragStartX = 0;
+        this.dragStartY = 0;
+        this.minZoom = 0.5;
+        this.maxZoom = 2;
+
+        this._registerEvents();
+        scene.events.on('shutdown', this.destroy, this);
+    }
+
+    _registerEvents() {
+        const input = this.scene.input;
+        input.on('pointerdown', this._onPointerDown, this);
+        input.on('pointerup', this._onPointerUp, this);
+        input.on('pointermove', this._onPointerMove, this);
+        input.on('wheel', this._onWheel, this);
+    }
+
+    _onPointerDown(pointer) {
+        this.isDragging = true;
+        this.dragStartX = pointer.x;
+        this.dragStartY = pointer.y;
+    }
+
+    _onPointerUp() {
+        this.isDragging = false;
+    }
+
+    _onPointerMove(pointer) {
+        if (!this.isDragging) return;
+        const cam = this.camera;
+        const dx = pointer.x - this.dragStartX;
+        const dy = pointer.y - this.dragStartY;
+        cam.scrollX -= dx / cam.zoom;
+        cam.scrollY -= dy / cam.zoom;
+        this.dragStartX = pointer.x;
+        this.dragStartY = pointer.y;
+    }
+
+    _onWheel(pointer, currentlyOver, dx, dy) {
+        const cam = this.camera;
+        const zoomFactor = 0.001;
+        const newZoom = Math.max(this.minZoom, Math.min(this.maxZoom, cam.zoom - dy * zoomFactor));
+        cam.setZoom(newZoom);
+    }
+
+    destroy() {
+        const input = this.scene.input;
+        input.off('pointerdown', this._onPointerDown, this);
+        input.off('pointerup', this._onPointerUp, this);
+        input.off('pointermove', this._onPointerMove, this);
+        input.off('wheel', this._onWheel, this);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `CameraControlEngine` utility for zoom and drag
- enable camera controls in `CursedForestBattleScene`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d1e0130c88327af73185074c335a9