### PR TITLE
Fix canvas scaling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -273,7 +273,9 @@ body {
 /* Phaser 게임 캔버스를 담는 컨테이너 */
 #game-container {
     position: absolute;
-    z-index: 1; 
+    width: 100%;
+    height: 100%;
+    z-index: 1;
 }
 
 /* --- 유닛 상세 정보창 스타일 --- */

--- a/src/game/utils/CanvasResolutionUtil.js
+++ b/src/game/utils/CanvasResolutionUtil.js
@@ -1,0 +1,7 @@
+export function adjustCanvasResolution(canvas) {
+    if (!canvas) return;
+    const pixelRatio = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * pixelRatio;
+    canvas.height = canvas.clientHeight * pixelRatio;
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,12 @@
 import StartGame from './game/main.js';
+import { adjustCanvasResolution } from './game/utils/CanvasResolutionUtil.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    StartGame('game-container');
+    const game = StartGame('game-container');
+
+    // Adjust canvas resolution to match device pixel ratio
+    adjustCanvasResolution(game.canvas);
+    window.addEventListener('resize', () => adjustCanvasResolution(game.canvas));
 
 });


### PR DESCRIPTION
## Summary
- ensure Phaser canvas stretches to fill available space
- adjust Phaser canvas resolution based on device pixel ratio

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d2614606c83279bca8333f76d2782