### PR TITLE
Apply pixel-perfect settings

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -24,13 +24,13 @@ const config = {
     backgroundColor: 'transparent', // 배경색을 투명하게 만듭니다.
     scale: {
         mode: Phaser.Scale.FIT,
-        autoCenter: Phaser.Scale.CENTER_BOTH
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+        // 정수 배율을 사용하여 픽셀 아트 표현을 개선합니다.
+        zoom: Math.floor(window.devicePixelRatio)
     },
     render: {
-        pixelArt: false,
-        antialias: true, // 안티에일리어싱을 활성화하여 이미지를 부드럽게 표현합니다.
-        resolution: window.devicePixelRatio || 1, // 기기의 픽셀 비율에 맞춰 해상도를 설정합니다.
-        roundPixels: true,
+        pixelArt: true,
+        antialias: false
     },
     // Boot 씬만 초기 설정에 등록합니다.
     // Boot 씬이 실행되면서 나머지 씬들을 동적으로 추가합니다.

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -17,10 +17,11 @@ export class Preloader extends Scene
 
         // 모든 리소스 로드 완료 후 로고를 중앙에 표시하고 스케일을 조정합니다.
         this.load.on('complete', () => {
-            // 로드된 모든 텍스처에 대해 트리리니어 필터를 적용하여
-            // 축소 시 화질 저하를 최소화합니다.
-            this.textures.getTextureKeys().forEach(key => {
-                this.textures.get(key).setFilter(Phaser.Textures.FilterMode.TRILINEAR);
+            // 유닛 스프라이트에는 Nearest 필터를 적용하여 픽셀 아트를 선명하게 표시합니다.
+            ['warrior', 'gunner', 'zombie'].forEach(key => {
+                if (this.textures.exists(key)) {
+                    this.textures.get(key).setFilter(Phaser.Textures.FilterMode.NEAREST);
+                }
             });
 
             const logo = this.add.image(512, 300, 'logo');
@@ -94,14 +95,11 @@ export class Preloader extends Scene
     create ()
     {
         // 전투 씬에서 사용될 주요 이미지들의 텍스처 필터링 모드를 설정하여 품질을 향상시킵니다.
-        const battleTextures = [
-            'warrior', 'gunner', 'zombie',
-            'battle-stage-cursed-forest', 'battle-stage-arena'
-        ];
+        const battleTextures = [ 'warrior', 'gunner', 'zombie' ];
 
         battleTextures.forEach(key => {
             if (this.textures.exists(key)) {
-                this.textures.get(key).setFilter(Phaser.Textures.FilterMode.TRILINEAR);
+                this.textures.get(key).setFilter(Phaser.Textures.FilterMode.NEAREST);
             }
         });
 

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -1,3 +1,5 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
 class FormationEngine {
     constructor() {
         this.positions = new Map();
@@ -34,6 +36,9 @@ class FormationEngine {
             if (!cell) return;
             const spriteKey = unit.spriteKey || unit.battleSprite || unit.id || unit.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
+            // 픽셀 아트 선명도를 위해 텍스처 필터를 Nearest로 설정합니다.
+            sprite.setTexture(spriteKey);
+            sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
             sprite.setData('unitId', unit.uniqueId);
             const texture = scene.textures.get(spriteKey);
             if (texture && texture.source[0]) {
@@ -66,6 +71,8 @@ class FormationEngine {
             cell.isOccupied = true;
             const spriteKey = mon.spriteKey || mon.battleSprite || mon.id || mon.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
+            sprite.setTexture(spriteKey);
+            sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
             sprite.setData('unitId', mon.uniqueId);
             const texture = scene.textures.get(spriteKey);
             if (texture && texture.source[0]) {


### PR DESCRIPTION
## Summary
- enable integer zoom and pixelArt rendering
- set NEAREST filtering for unit textures when loading
- apply NEAREST filtering to sprites in FormationEngine

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d27326f08832796ba075d6d507a76