### PR TITLE
Add placement debug logs

### DIFF
--- a/src/game/debug/DebugPlacementLogManager.js
+++ b/src/game/debug/DebugPlacementLogManager.js
@@ -1,0 +1,30 @@
+import { debugLogEngine } from '../utils/DebugLogEngine.js';
+
+class DebugPlacementLogManager {
+    constructor() {
+        this.name = 'DebugPlacement';
+        debugLogEngine.register(this);
+    }
+
+    /**
+     * 유닛 스프라이트가 생성된 좌표를 기록합니다.
+     * @param {string} unitName - 유닛 이름
+     * @param {number} x - 스프라이트 X 좌표
+     * @param {number} y - 스프라이트 Y 좌표
+     */
+    logSpriteCreation(unitName, x, y) {
+        debugLogEngine.log(this.name, `Sprite '${unitName}' created at (${x}, ${y})`);
+    }
+
+    /**
+     * 이름표 DOM 요소가 생성된 좌표를 기록합니다.
+     * @param {string} unitName - 유닛 이름
+     * @param {number} x - 이름표 기준 X 좌표
+     * @param {number} y - 이름표 기준 Y 좌표
+     */
+    logNameplateCreation(unitName, x, y) {
+        debugLogEngine.log(this.name, `Nameplate for '${unitName}' created at (${x}, ${y})`);
+    }
+}
+
+export const debugPlacementLogManager = new DebugPlacementLogManager();

--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -1,4 +1,5 @@
 import { DOMEngine } from '../utils/DOMEngine.js';
+import { debugPlacementLogManager } from '../debug/DebugPlacementLogManager.js';
 
 export class BattleDOMEngine {
     constructor(scene, domEngine) {
@@ -18,5 +19,6 @@ export class BattleDOMEngine {
         };
         const offset = { x: 0, y: sprite.displayHeight / 2 };
         this.domEngine.createSyncedText(sprite, name, style, offset);
+        debugPlacementLogManager.logNameplateCreation(name, sprite.x + offset.x, sprite.y + offset.y);
     }
 }

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -1,4 +1,5 @@
 import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { debugPlacementLogManager } from '../debug/DebugPlacementLogManager.js';
 
 class FormationEngine {
     constructor() {
@@ -36,6 +37,7 @@ class FormationEngine {
             if (!cell) return;
             const spriteKey = unit.spriteKey || unit.battleSprite || unit.id || unit.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
+            debugPlacementLogManager.logSpriteCreation(unit.instanceName || unit.name, cell.x, cell.y);
             // 픽셀 아트 선명도를 위해 텍스처 필터를 Nearest로 설정합니다.
             sprite.setTexture(spriteKey);
             sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
@@ -71,6 +73,7 @@ class FormationEngine {
             cell.isOccupied = true;
             const spriteKey = mon.spriteKey || mon.battleSprite || mon.id || mon.name;
             const sprite = scene.add.image(cell.x, cell.y, spriteKey);
+            debugPlacementLogManager.logSpriteCreation(mon.instanceName || mon.name, cell.x, cell.y);
             sprite.setTexture(spriteKey);
             sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
             sprite.setData('unitId', mon.uniqueId);


### PR DESCRIPTION
## Summary
- log sprite and nameplate creation positions for developer mode debugging
- track placement via new `DebugPlacementLogManager`

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d293ad660832796b5978003eb9d61