### PR TITLE
Increase battle grid tile size

### DIFF
--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -27,9 +27,19 @@ export class BattleStageManager {
 
         const scale = Math.max(scaleX, scaleY);
         bg.setScale(scale);
-        const cellWidth = width / 16;
-        const cellHeight = height / 9;
-        this.gridEngine.createGrid({ x: 0, y: 0, cols: 16, rows: 9, cellWidth, cellHeight });
+        const cellWidth = 512;
+        const cellHeight = 512;
+        const cols = 16;
+        const rows = 9;
+        this.gridEngine.createGrid({ x: 0, y: 0, cols, rows, cellWidth, cellHeight });
+
+        // 카메라를 배틀 그리드 전체가 화면에 들어오도록 조정합니다.
+        const cam = this.scene.cameras.main;
+        const zoomX = width / (cols * cellWidth);
+        const zoomY = height / (rows * cellHeight);
+        const zoom = Math.min(zoomX, zoomY);
+        cam.setZoom(zoom);
+        cam.centerOn((cols * cellWidth) / 2, (rows * cellHeight) / 2);
         // 그리드 선을 보이지 않게 설정
         if (this.gridEngine.graphics) {
             this.gridEngine.graphics.setAlpha(0);

--- a/src/game/utils/CameraControlEngine.js
+++ b/src/game/utils/CameraControlEngine.js
@@ -5,7 +5,8 @@ export class CameraControlEngine {
         this.isDragging = false;
         this.dragStartX = 0;
         this.dragStartY = 0;
-        this.minZoom = 0.5;
+        // 전투 타일 크기가 커진 관계로 더 넓은 영역을 볼 수 있도록 최소 줌값을 낮춥니다.
+        this.minZoom = 0.1;
         this.maxZoom = 3;
 
         this._registerEvents();


### PR DESCRIPTION
## Summary
- make battle stage tiles 512x512
- allow wider zoom in CameraControlEngine
- auto-fit camera to show entire battle grid

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d2fbc8e6883278da63b3e75de9379