### PR TITLE
Implement Y-mapping for battle units

### DIFF
--- a/src/game/utils/BattleStageManager.js
+++ b/src/game/utils/BattleStageManager.js
@@ -27,8 +27,9 @@ export class BattleStageManager {
 
         const scale = Math.max(scaleX, scaleY);
         bg.setScale(scale);
-        const cellWidth = width / 16;
-        const cellHeight = height / 9;
+        // 전투 그리드 타일 크기를 고정값 120으로 설정합니다.
+        const cellWidth = 120;
+        const cellHeight = 120;
         this.gridEngine.createGrid({ x: 0, y: 0, cols: 16, rows: 9, cellWidth, cellHeight });
         // 그리드 선을 보이지 않게 설정
         if (this.gridEngine.graphics) {

--- a/src/game/utils/FormationEngine.js
+++ b/src/game/utils/FormationEngine.js
@@ -43,14 +43,16 @@ class FormationEngine {
             sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
             sprite.setData('unitId', unit.uniqueId);
             const texture = scene.textures.get(spriteKey);
+            sprite.setOrigin(0.5, 1);
+            const targetSize = 240;
             if (texture && texture.source[0]) {
                 const scale = Math.min(
-                    cell.width / texture.source[0].width,
-                    cell.height / texture.source[0].height
+                    targetSize / texture.source[0].width,
+                    targetSize / texture.source[0].height
                 );
                 sprite.setScale(scale);
             } else {
-                sprite.setDisplaySize(cell.width, cell.height);
+                sprite.setDisplaySize(targetSize, targetSize);
             }
             sprites.push(sprite);
         });
@@ -78,14 +80,16 @@ class FormationEngine {
             sprite.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
             sprite.setData('unitId', mon.uniqueId);
             const texture = scene.textures.get(spriteKey);
+            sprite.setOrigin(0.5, 1);
+            const targetSize = 240;
             if (texture && texture.source[0]) {
                 const scale = Math.min(
-                    cell.width / texture.source[0].width,
-                    cell.height / texture.source[0].height
+                    targetSize / texture.source[0].width,
+                    targetSize / texture.source[0].height
                 );
                 sprite.setScale(scale);
             } else {
-                sprite.setDisplaySize(cell.width, cell.height);
+                sprite.setDisplaySize(targetSize, targetSize);
             }
             sprites.push(sprite);
         });

--- a/src/game/utils/GridEngine.js
+++ b/src/game/utils/GridEngine.js
@@ -33,7 +33,8 @@ export class GridEngine {
                 // 각 칸의 정보를 객체로 만들어 배열에 저장
                 const cell = {
                     x: cellX + cellWidth / 2,
-                    y: cellY + cellHeight / 2,
+                    // y 좌표는 타일의 바닥 중앙을 기준으로 합니다.
+                    y: cellY + cellHeight,
                     width: cellWidth,
                     height: cellHeight,
                     col: col,


### PR DESCRIPTION
## Summary
- keep battle grid tiles at 120px while fixing unit placement
- enlarge battle units to 240px
- anchor units to the bottom of each tile for proper Y mapping

## Testing
- `python3 -m http.server 8000` & `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d3451a050832783f2911dfa7c3b5f