### PR TITLE
Adjust nameplate offset

### DIFF
--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -17,8 +17,12 @@ export class BattleDOMEngine {
             whiteSpace: 'nowrap',
             pointerEvents: 'none'
         };
-        const offset = { x: 0, y: sprite.displayHeight / 2 };
+        const offset = { x: 0, y: -sprite.displayHeight / 2 };
         this.domEngine.createSyncedText(sprite, name, style, offset);
-        debugPlacementLogManager.logNameplateCreation(name, sprite.x + offset.x, sprite.y + offset.y);
+        debugPlacementLogManager.logNameplateCreation(
+            name,
+            sprite.x + offset.x,
+            sprite.y + offset.y
+        );
     }
 }


### PR DESCRIPTION
## Summary
- tweak nameplate offset in BattleDOMEngine so labels appear above units

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687d3587249483279bd51ee68322b7c6