### PR TITLE
Fix nameplate position

### DIFF
--- a/src/game/dom/BattleDOMEngine.js
+++ b/src/game/dom/BattleDOMEngine.js
@@ -17,7 +17,9 @@ export class BattleDOMEngine {
             whiteSpace: 'nowrap',
             pointerEvents: 'none'
         };
-        const offset = { x: 0, y: sprite.displayHeight / 2 };
+        // 이름표가 유닛 위에 위치하도록 오프셋을 조정합니다.
+        // 약간의 간격을 두어 시각적으로 분리합니다.
+        const offset = { x: 0, y: -sprite.displayHeight / 2 - 10 };
         this.domEngine.createSyncedText(sprite, name, style, offset);
         debugPlacementLogManager.logNameplateCreation(name, sprite.x + offset.x, sprite.y + offset.y);
     }

--- a/src/game/utils/DOMEngine.js
+++ b/src/game/utils/DOMEngine.js
@@ -33,7 +33,8 @@ export class DOMEngine {
         const textElement = document.createElement('div');
         textElement.innerText = text;
         textElement.style.position = 'relative';
-        textElement.style.transform = 'translate(-50%, 0)';
+        // 기준점을 중앙 상단으로 변경하여 오프셋이 정확히 적용되도록 한다
+        textElement.style.transform = 'translate(-50%, -100%)';
         Object.assign(textElement.style, style); // 전달된 스타일 적용
 
         wrapper.appendChild(textElement);


### PR DESCRIPTION
## Summary
- move unit nameplates above sprites
- adjust DOM engine transform so text offset uses top center

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687d4726de5083278ee69871fc4e4222