### PR TITLE
Implement Phaser nameplate layer

### DIFF
--- a/src/game/scenes/CursedForestBattleScene.js
+++ b/src/game/scenes/CursedForestBattleScene.js
@@ -6,16 +6,14 @@ import { partyEngine } from '../utils/PartyEngine.js';
 import { monsterEngine } from '../utils/MonsterEngine.js';
 import { getMonsterBase } from '../data/monster.js';
 import { CameraControlEngine } from '../utils/CameraControlEngine.js';
-import { DOMEngine } from '../utils/DOMEngine.js';
-import { BattleDOMEngine } from '../dom/BattleDOMEngine.js';
+import { NameplateLayer } from '../utils/NameplateLayer.js';
 
 export class CursedForestBattleScene extends Scene {
     constructor() {
         super('CursedForestBattle');
         this.stageManager = null;
         this.cameraControl = null;
-        this.domEngine = null;
-        this.battleDom = null;
+        this.nameplateLayer = null;
     }
 
     create() {
@@ -28,8 +26,7 @@ export class CursedForestBattleScene extends Scene {
         this.stageManager = new BattleStageManager(this);
         this.stageManager.createStage('battle-stage-cursed-forest');
         this.cameraControl = new CameraControlEngine(this);
-        this.domEngine = new DOMEngine(this);
-        this.battleDom = new BattleDOMEngine(this, this.domEngine);
+        this.nameplateLayer = new NameplateLayer(this);
 
         // 아군 배치
         const partyIds = partyEngine.getPartyMembers().filter(id => id !== undefined);
@@ -47,11 +44,11 @@ export class CursedForestBattleScene extends Scene {
 
         allySprites.forEach((sprite, idx) => {
             const unit = partyUnits[idx];
-            if (unit) this.battleDom.addUnitName(sprite, unit.instanceName || unit.name, true);
+            if (unit) this.nameplateLayer.addNameplate(sprite, unit.instanceName || unit.name, true);
         });
         enemySprites.forEach((sprite, idx) => {
             const unit = monsters[idx];
-            if (unit) this.battleDom.addUnitName(sprite, unit.instanceName || unit.name, false);
+            if (unit) this.nameplateLayer.addNameplate(sprite, unit.instanceName || unit.name, false);
         });
 
         this.events.on('shutdown', () => {
@@ -67,8 +64,10 @@ export class CursedForestBattleScene extends Scene {
                 this.cameraControl.destroy();
                 this.cameraControl = null;
             }
-            this.domEngine = null;
-            this.battleDom = null;
+            if (this.nameplateLayer) {
+                this.nameplateLayer.destroy();
+                this.nameplateLayer = null;
+            }
         });
     }
 }

--- a/src/game/utils/NameplateLayer.js
+++ b/src/game/utils/NameplateLayer.js
@@ -1,0 +1,55 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+import { debugPlacementLogManager } from '../debug/DebugPlacementLogManager.js';
+
+export class NameplateLayer {
+    constructor(scene) {
+        this.scene = scene;
+        const width = scene.scale.gameSize.width * 2;
+        const height = scene.scale.gameSize.height * 2;
+        this.rt = scene.add.renderTexture(0, 0, width, height).setOrigin(0, 0);
+        this.rt.setScrollFactor(0);
+        this.rt.setDepth(1000);
+        this.rt.setScale(0.5);
+
+        this.nameplates = [];
+
+        scene.events.on('update', this.update, this);
+        scene.events.on('shutdown', this.destroy, this);
+    }
+
+    addNameplate(sprite, name, isAlly = true) {
+        const style = {
+            fontFamily: 'Arial',
+            fontSize: '24px',
+            padding: { x: 4, y: 2 },
+            color: '#ffffff',
+            backgroundColor: isAlly ? 'rgba(0,0,255,0.6)' : 'rgba(255,0,0,0.6)'
+        };
+        const text = this.scene.add.text(0, 0, name, style).setOrigin(0.5, 0);
+        text.visible = false;
+        this.nameplates.push({ sprite, text });
+        const offsetY = sprite.displayHeight / 2;
+        debugPlacementLogManager.logNameplateCreation(name, sprite.x, sprite.y + offsetY);
+    }
+
+    update() {
+        if (!this.rt) return;
+        this.rt.clear();
+        this.nameplates.forEach(({ sprite, text }) => {
+            if (!sprite.scene) return;
+            const offsetY = sprite.displayHeight / 2;
+            text.setPosition(sprite.x, sprite.y + offsetY);
+            this.rt.draw(text, text.x * 2, text.y * 2);
+        });
+    }
+
+    destroy() {
+        if (this.rt) {
+            this.rt.destroy();
+            this.rt = null;
+        }
+        this.nameplates.forEach(({ text }) => text.destroy());
+        this.nameplates = [];
+        this.scene.events.off('update', this.update, this);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `NameplateLayer` that renders nameplates on an off‑screen RenderTexture
- switch `CursedForestBattleScene` to use the Phaser-based nameplate layer

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d45fb69288327987fa46e20c4b4e5