### PR TITLE
Switch Phaser renderer to Canvas

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -15,7 +15,7 @@ import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.
 //  Find out more information about the Game Config at:
 //  https://docs.phaser.io/api-documentation/typedef/types-core#gameconfig
 const config = {
-    type: Phaser.AUTO,
+    type: Phaser.CANVAS,
     // SurveyEngine에서 캔버스 크기를 가져옵니다.
     width: surveyEngine.canvas.width,
     height: surveyEngine.canvas.height,


### PR DESCRIPTION
## Summary
- force Phaser to use Canvas renderer instead of WebGL

## Testing
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d571e703c832795dcc10bb3b8d971